### PR TITLE
Refactor 'reserved_words' to patterns, not strings

### DIFF
--- a/lib/query_string_search/matchers/match_attribute.rb
+++ b/lib/query_string_search/matchers/match_attribute.rb
@@ -4,10 +4,13 @@ class MatchAttribute < QueryStringSearch::AbstractMatcher
   end
 
   def self.reserved_words
-    %w(true all)
+    [
+      /^true$/,
+      /^all$/
+    ]
   end
 
   def self.build_me?(_, search_param)
-    reserved_words.include?(search_param)
+    reserved_words.any? { |r| r.match(search_param) }
   end
 end

--- a/lib/query_string_search/matchers/match_attribute_value.rb
+++ b/lib/query_string_search/matchers/match_attribute_value.rb
@@ -6,6 +6,8 @@ class MatchAttributeValue < QueryStringSearch::AbstractMatcher
   end
 
   def self.build_me?(search_type, search_param)
-    search_param && search_type && !all_reserved_words.include?(search_param)
+    search_param &&
+      search_type &&
+      all_reserved_words.none? { |r| r.match(search_param) }
   end
 end

--- a/lib/query_string_search/matchers/match_no_attribute.rb
+++ b/lib/query_string_search/matchers/match_no_attribute.rb
@@ -4,10 +4,13 @@ class MatchNoAttribute < QueryStringSearch::AbstractMatcher
   end
 
   def self.reserved_words
-    %w(false none)
+    [
+      /^false$/,
+      /^none$/
+    ]
   end
 
   def self.build_me?(_, search_param)
-    reserved_words.include?(search_param)
+    reserved_words.any? { |r| r.match(search_param) }
   end
 end

--- a/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
@@ -46,14 +46,14 @@ RSpec.describe MatchAttributeValue do
   describe "build_me?" do
     describe "given a non-nil search_type and search_param" do
       it "is true" do
-        expect(MatchAttributeValue.build_me?(rand, rand)).to be_truthy
+        expect(MatchAttributeValue.build_me?(rand.to_s, rand.to_s)).to be_truthy
       end
     end
 
     describe "given a nil search_type or search_param" do
       it "is false" do
-        expect(MatchAttributeValue.build_me?(rand, nil)).to be_falsey
-        expect(MatchAttributeValue.build_me?(nil, rand)).to be_falsey
+        expect(MatchAttributeValue.build_me?(rand.to_s, nil)).to be_falsey
+        expect(MatchAttributeValue.build_me?(nil, rand.to_s)).to be_falsey
         expect(MatchAttributeValue.build_me?(nil, nil)).to be_falsey
       end
     end


### PR DESCRIPTION
While doing some design for this feature:
https://github.com/umn-asr/query_string_search/issues/2 we found that
having the reserved_words be string was going to be a problem. This
commit is to refactor away those strings and replace them with regex
patterns.

These patterns will be more flexible going forward. The string approach
meant that the search value and the reserved word had to match exactly.
A regex approach will let us see if the search value matches a pattern.
