### PR TITLE
Implement or matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Returns every movie without ratings.
 
 Returns every movie with a year of 1994
 
+### Return all data that matches one of many attributes
+
+`movies?q=year=1994|1995`
+
+Returns all movies with a year of 1994 or 1995
+
 ### Combining Searches
 
 Search criteria can be separated with commas

--- a/lib/query_string_search/matchers/match_multiple_attribute_values.rb
+++ b/lib/query_string_search/matchers/match_multiple_attribute_values.rb
@@ -1,0 +1,21 @@
+class MatchMultipleAttributeValues < QueryStringSearch::AbstractMatcher
+  def match?(target)
+    match_with_contingency do
+      value.include?(target.public_send(attribute).to_s.upcase)
+    end
+  end
+
+  def self.reserved_words
+    [
+      /^\w+\|\w+/
+    ]
+  end
+
+  def value=(x)
+    super(x.split("|").map {|a| a.upcase})
+  end
+
+  def self.build_me?(_, search_param)
+    reserved_words.any? { |r| r.match(search_param) }
+  end
+end

--- a/lib/query_string_search/matchers/match_multiple_attribute_values.rb
+++ b/lib/query_string_search/matchers/match_multiple_attribute_values.rb
@@ -12,7 +12,7 @@ class MatchMultipleAttributeValues < QueryStringSearch::AbstractMatcher
   end
 
   def value=(x)
-    super(x.split("|").map {|a| a.upcase})
+    super(x.split("|").map(&:upcase))
   end
 
   def self.build_me?(_, search_param)

--- a/spec/doubles/search_target.rb
+++ b/spec/doubles/search_target.rb
@@ -1,0 +1,6 @@
+class Target
+  attr_accessor :search_attr
+  def initialize(search_attr = nil)
+    self.search_attr = search_attr
+  end
+end

--- a/spec/doubles/search_target.rb
+++ b/spec/doubles/search_target.rb
@@ -1,6 +1,6 @@
 class SearchTarget
-  attr_accessor :search_attr
-  def initialize(search_attr: nil)
-    self.search_attr = search_attr
+  attr_accessor :property
+  def initialize(property: nil)
+    self.property = property
   end
 end

--- a/spec/doubles/search_target.rb
+++ b/spec/doubles/search_target.rb
@@ -1,6 +1,6 @@
-class Target
+class SearchTarget
   attr_accessor :search_attr
-  def initialize(search_attr = nil)
+  def initialize(search_attr: nil)
     self.search_attr = search_attr
   end
 end

--- a/spec/features/find_records_that_match_one_of_many_attributes_spec.rb
+++ b/spec/features/find_records_that_match_one_of_many_attributes_spec.rb
@@ -3,7 +3,7 @@ require_relative "../fixtures/movie"
 
 RSpec.describe "Finding data that matches one of many attributes" do
   let(:data_set) { Movie.random_collection }
-  let(:movies_in_1994_or_1995) { data_set.select { |d| ["1994", "1995"].include?(d.year) } }
+  let(:movies_in_1994_or_1995) { data_set.select { |d| %w(1994 1995).include?(d.year) } }
 
   it "Returns records that match the requested value" do
     results = QueryStringSearch.new(data_set, "year=1994|1995").results

--- a/spec/features/find_records_that_match_one_of_many_attributes_spec.rb
+++ b/spec/features/find_records_that_match_one_of_many_attributes_spec.rb
@@ -1,0 +1,13 @@
+require_relative "../../lib/query_string_search"
+require_relative "../fixtures/movie"
+
+RSpec.describe "Finding data that matches one of many attributes" do
+  let(:data_set) { Movie.random_collection }
+  let(:movies_in_1994_or_1995) { data_set.select { |d| ["1994", "1995"].include?(d.year) } }
+
+  it "Returns records that match the requested value" do
+    results = QueryStringSearch.new(data_set, "year=1994|1995").results
+
+    expect(results).to eq(movies_in_1994_or_1995)
+  end
+end

--- a/spec/lib/query_string_search/matchers/match_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../../doubles/search_target"
 RSpec.describe MatchAttribute do
   describe "match?" do
     describe "if the target's attribute is not nil" do
-      let(:target) { Target.new("search_value") }
+      let(:target) { SearchTarget.new(search_attr: "search_value") }
       let(:subject) { MatchAttribute.new(:search_attr) }
 
       it "is true" do
@@ -13,7 +13,7 @@ RSpec.describe MatchAttribute do
     end
 
     describe "if the target's attribute is true" do
-      let(:target) { Target.new(true) }
+      let(:target) { SearchTarget.new(search_attr: true) }
       let(:subject) { MatchAttribute.new(:search_attr) }
 
       it "is true" do
@@ -22,7 +22,7 @@ RSpec.describe MatchAttribute do
     end
 
     describe "if the target's attribute is nil" do
-      let(:target) { Target.new(nil) }
+      let(:target) { SearchTarget.new(search_attr: nil) }
       let(:subject) { MatchAttribute.new(:search_attr) }
 
       it "is false" do
@@ -31,7 +31,7 @@ RSpec.describe MatchAttribute do
     end
 
     describe "if the target's attribute is false" do
-      let(:target) { Target.new(false) }
+      let(:target) { SearchTarget.new(search_attr: false) }
       let(:subject) { MatchAttribute.new(:search_attr) }
 
       it "is true" do
@@ -40,7 +40,7 @@ RSpec.describe MatchAttribute do
     end
 
     describe "if the target doesn't have the attribute" do
-      let(:target) { Target.new(rand) }
+      let(:target) { SearchTarget.new(search_attr: rand) }
       let(:subject) { MatchAttribute.new(:bad_attr) }
 
       it "is false" do

--- a/spec/lib/query_string_search/matchers/match_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_spec.rb
@@ -4,8 +4,8 @@ require_relative "../../../doubles/search_target"
 RSpec.describe MatchAttribute do
   describe "match?" do
     describe "if the target's attribute is not nil" do
-      let(:target) { SearchTarget.new(search_attr: "search_value") }
-      let(:subject) { MatchAttribute.new(:search_attr) }
+      let(:target) { SearchTarget.new(property: "search_value") }
+      let(:subject) { MatchAttribute.new(:property) }
 
       it "is true" do
         expect(subject.match?(target)).to be_truthy
@@ -13,8 +13,8 @@ RSpec.describe MatchAttribute do
     end
 
     describe "if the target's attribute is true" do
-      let(:target) { SearchTarget.new(search_attr: true) }
-      let(:subject) { MatchAttribute.new(:search_attr) }
+      let(:target) { SearchTarget.new(property: true) }
+      let(:subject) { MatchAttribute.new(:property) }
 
       it "is true" do
         expect(subject.match?(target)).to be_truthy
@@ -22,8 +22,8 @@ RSpec.describe MatchAttribute do
     end
 
     describe "if the target's attribute is nil" do
-      let(:target) { SearchTarget.new(search_attr: nil) }
-      let(:subject) { MatchAttribute.new(:search_attr) }
+      let(:target) { SearchTarget.new(property: nil) }
+      let(:subject) { MatchAttribute.new(:property) }
 
       it "is false" do
         expect(subject.match?(target)).to be_falsey
@@ -31,8 +31,8 @@ RSpec.describe MatchAttribute do
     end
 
     describe "if the target's attribute is false" do
-      let(:target) { SearchTarget.new(search_attr: false) }
-      let(:subject) { MatchAttribute.new(:search_attr) }
+      let(:target) { SearchTarget.new(property: false) }
+      let(:subject) { MatchAttribute.new(:property) }
 
       it "is true" do
         expect(subject.match?(target)).to be_falsey
@@ -40,7 +40,7 @@ RSpec.describe MatchAttribute do
     end
 
     describe "if the target doesn't have the attribute" do
-      let(:target) { SearchTarget.new(search_attr: rand) }
+      let(:target) { SearchTarget.new(property: rand) }
       let(:subject) { MatchAttribute.new(:bad_attr) }
 
       it "is false" do

--- a/spec/lib/query_string_search/matchers/match_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_spec.rb
@@ -1,4 +1,5 @@
 require_relative "../../../../lib/query_string_search/abstract_matcher"
+require_relative "../../../doubles/search_target"
 
 RSpec.describe MatchAttribute do
   describe "match?" do

--- a/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../../doubles/search_target"
 RSpec.describe MatchAttributeValue do
   describe "match?" do
     describe "given a target with an attribute that matches the Parameter's attribute" do
-      let(:target) { Target.new("search_value") }
+      let(:target) { SearchTarget.new(search_attr: "search_value") }
       let(:value) { "search_value" }
       let(:subject) { MatchAttributeValue.new(:search_attr, value) }
 
@@ -14,7 +14,7 @@ RSpec.describe MatchAttributeValue do
     end
 
     describe "given a value with spaces" do
-      let(:target) { Target.new("search value") }
+      let(:target) { SearchTarget.new(search_attr: "search value") }
       let(:value) { "search value" }
       let(:subject) { MatchAttributeValue.new(:search_attr, value) }
 
@@ -24,7 +24,7 @@ RSpec.describe MatchAttributeValue do
     end
 
     describe "given a target with an attribute that does not match the Parameter's attribute" do
-      let(:target) { Target.new("other_value") }
+      let(:target) { SearchTarget.new(search_attr: "other_value") }
       let(:value) { "search_value" }
       let(:subject) { MatchAttributeValue.new(:search_attr, value) }
 
@@ -35,7 +35,7 @@ RSpec.describe MatchAttributeValue do
 
     describe "if the target doesn't have the attribute" do
       let(:value) { "search_value" }
-      let(:target) { Target.new(value) }
+      let(:target) { SearchTarget.new(search_attr: value) }
       let(:subject) { MatchAttribute.new(:bad_attr, value) }
 
       it "is false" do

--- a/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
@@ -4,9 +4,9 @@ require_relative "../../../doubles/search_target"
 RSpec.describe MatchAttributeValue do
   describe "match?" do
     describe "given a target with an attribute that matches the Parameter's attribute" do
-      let(:target) { SearchTarget.new(search_attr: "search_value") }
+      let(:target) { SearchTarget.new(property: "search_value") }
       let(:value) { "search_value" }
-      let(:subject) { MatchAttributeValue.new(:search_attr, value) }
+      let(:subject) { MatchAttributeValue.new(:property, value) }
 
       it "returns true" do
         expect(subject.match?(target)).to be_truthy
@@ -14,9 +14,9 @@ RSpec.describe MatchAttributeValue do
     end
 
     describe "given a value with spaces" do
-      let(:target) { SearchTarget.new(search_attr: "search value") }
+      let(:target) { SearchTarget.new(property: "search value") }
       let(:value) { "search value" }
-      let(:subject) { MatchAttributeValue.new(:search_attr, value) }
+      let(:subject) { MatchAttributeValue.new(:property, value) }
 
       it "returns true" do
         expect(subject.match?(target)).to be_truthy
@@ -24,9 +24,9 @@ RSpec.describe MatchAttributeValue do
     end
 
     describe "given a target with an attribute that does not match the Parameter's attribute" do
-      let(:target) { SearchTarget.new(search_attr: "other_value") }
+      let(:target) { SearchTarget.new(property: "other_value") }
       let(:value) { "search_value" }
-      let(:subject) { MatchAttributeValue.new(:search_attr, value) }
+      let(:subject) { MatchAttributeValue.new(:property, value) }
 
       it "returns false" do
         expect(subject.match?(target)).to be_falsey
@@ -35,7 +35,7 @@ RSpec.describe MatchAttributeValue do
 
     describe "if the target doesn't have the attribute" do
       let(:value) { "search_value" }
-      let(:target) { SearchTarget.new(search_attr: value) }
+      let(:target) { SearchTarget.new(property: value) }
       let(:subject) { MatchAttribute.new(:bad_attr, value) }
 
       it "is false" do

--- a/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
@@ -1,4 +1,5 @@
 require_relative "../../../../lib/query_string_search/abstract_matcher"
+require_relative "../../../doubles/search_target"
 
 RSpec.describe MatchAttributeValue do
   describe "match?" do

--- a/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe MatchAttributeValue do
 
     describe "given a value with spaces" do
       let(:target) { SearchTarget.new(property: "search value") }
-      let(:subject) { MatchAttributeValue.new(:property, "search_value") }
+      let(:subject) { MatchAttributeValue.new(:property, "search value") }
 
       it "returns true" do
         expect(subject.match?(target)).to be_truthy

--- a/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe MatchAttributeValue do
   describe "match?" do
     describe "given a target with an attribute that matches the Parameter's attribute" do
       let(:target) { SearchTarget.new(property: "search_value") }
-      let(:value) { "search_value" }
-      let(:subject) { MatchAttributeValue.new(:property, value) }
+      let(:subject) { MatchAttributeValue.new(:property, "search_value") }
 
       it "returns true" do
         expect(subject.match?(target)).to be_truthy
@@ -15,8 +14,7 @@ RSpec.describe MatchAttributeValue do
 
     describe "given a value with spaces" do
       let(:target) { SearchTarget.new(property: "search value") }
-      let(:value) { "search value" }
-      let(:subject) { MatchAttributeValue.new(:property, value) }
+      let(:subject) { MatchAttributeValue.new(:property, "search_value") }
 
       it "returns true" do
         expect(subject.match?(target)).to be_truthy
@@ -25,8 +23,7 @@ RSpec.describe MatchAttributeValue do
 
     describe "given a target with an attribute that does not match the Parameter's attribute" do
       let(:target) { SearchTarget.new(property: "other_value") }
-      let(:value) { "search_value" }
-      let(:subject) { MatchAttributeValue.new(:property, value) }
+      let(:subject) { MatchAttributeValue.new(:property, "search_value") }
 
       it "returns false" do
         expect(subject.match?(target)).to be_falsey
@@ -34,9 +31,8 @@ RSpec.describe MatchAttributeValue do
     end
 
     describe "if the target doesn't have the attribute" do
-      let(:value) { "search_value" }
-      let(:target) { SearchTarget.new(property: value) }
-      let(:subject) { MatchAttribute.new(:bad_attr, value) }
+      let(:target) { SearchTarget.new(property: "search_value") }
+      let(:subject) { MatchAttribute.new(:bad_attr, "search_value") }
 
       it "is false" do
         expect(subject.match?(target)).to be_falsey

--- a/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
@@ -4,14 +4,14 @@ require_relative "../../../doubles/search_target"
 RSpec.describe MatchMultipleAttributeValues do
   describe "match?" do
     it "matches if the target's attribute is one of the values" do
-      target = SearchTarget.new(search_attr: "1994")
-      matcher = MatchMultipleAttributeValues.new(:search_attr, "1994|1995")
+      target = SearchTarget.new(property: "1994")
+      matcher = MatchMultipleAttributeValues.new(:property, "1994|1995")
       expect(matcher.match?(target)).to be_truthy
     end
 
     it "does not match if the target's attribute is not one of the values" do
-      target = SearchTarget.new(search_attr: "199")
-      matcher = MatchMultipleAttributeValues.new(:search_attr, "1994|1995")
+      target = SearchTarget.new(property: "199")
+      matcher = MatchMultipleAttributeValues.new(:property, "1994|1995")
       expect(matcher.match?(target)).to be_falsey
     end
   end

--- a/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
@@ -1,0 +1,40 @@
+require_relative "../../../../lib/query_string_search/abstract_matcher"
+require_relative "../../../doubles/search_target"
+
+RSpec.describe MatchMultipleAttributeValues do
+  describe "match?" do
+    it "matches if the target's attribute is one of the values" do
+      target = Target.new
+      target.search_attr = "1994"
+      matcher = MatchMultipleAttributeValues.new(:search_attr, "1994|1995")
+      expect(matcher.match?(target)).to be_truthy
+    end
+
+    it "does not match if the target's attribute is not one of the values" do
+      target = Target.new
+      target.search_attr = "199"
+      matcher = MatchMultipleAttributeValues.new(:search_attr, "1994|1995")
+      expect(matcher.match?(target)).to be_falsey
+    end
+  end
+
+  describe "build_me?" do
+    describe "given a search type and search param that contains a pipe" do
+      it "is true" do
+        expect(MatchMultipleAttributeValues.build_me?(rand, "x|y")).to be_truthy
+      end
+    end
+
+    describe "given a search type and search param that starts with a pipe" do
+      it "is false" do
+        expect(MatchMultipleAttributeValues.build_me?(rand, "|x|y")).to be_falsey
+      end
+    end
+
+    describe "given a search type without a pipe" do
+      it "is false" do
+        expect(MatchMultipleAttributeValues.build_me?(rand, "xy")).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe MatchMultipleAttributeValues do
       matcher = MatchMultipleAttributeValues.new(:property, "1994|1995")
       expect(matcher.match?(target)).to be_falsey
     end
+
+    describe "if the target doesn't have the attribute" do
+      it "is false" do
+        target = SearchTarget.new(property: "1994")
+        subject = MatchAttribute.new(:bad_attr, "1994|1995")
+
+        expect(subject.match?(target)).to be_falsey
+      end
+    end
   end
 
   describe "build_me?" do

--- a/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
@@ -4,15 +4,13 @@ require_relative "../../../doubles/search_target"
 RSpec.describe MatchMultipleAttributeValues do
   describe "match?" do
     it "matches if the target's attribute is one of the values" do
-      target = Target.new
-      target.search_attr = "1994"
+      target = SearchTarget.new(search_attr: "1994")
       matcher = MatchMultipleAttributeValues.new(:search_attr, "1994|1995")
       expect(matcher.match?(target)).to be_truthy
     end
 
     it "does not match if the target's attribute is not one of the values" do
-      target = Target.new
-      target.search_attr = "199"
+      target = SearchTarget.new(search_attr: "199")
       matcher = MatchMultipleAttributeValues.new(:search_attr, "1994|1995")
       expect(matcher.match?(target)).to be_falsey
     end

--- a/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../../doubles/search_target"
 RSpec.describe MatchNoAttribute do
   describe "match?" do
     describe "if the target's attribute is not nil" do
-      let(:target) { Target.new("search_value") }
+      let(:target) { SearchTarget.new(search_attr: "search_value") }
       let(:subject) { MatchNoAttribute.new(:search_attr) }
 
       it "is false" do
@@ -13,7 +13,7 @@ RSpec.describe MatchNoAttribute do
     end
 
     describe "if the target's attribute is true" do
-      let(:target) { Target.new(true) }
+      let(:target) { SearchTarget.new(search_attr: true) }
       let(:subject) { MatchNoAttribute.new(:search_attr) }
 
       it "is true" do
@@ -22,7 +22,7 @@ RSpec.describe MatchNoAttribute do
     end
 
     describe "if the target's attribute is false" do
-      let(:target) { Target.new(false) }
+      let(:target) { SearchTarget.new(search_attr: false) }
       let(:subject) { MatchNoAttribute.new(:search_attr) }
 
       it "is true" do
@@ -31,7 +31,7 @@ RSpec.describe MatchNoAttribute do
     end
 
     describe "if the target's attribute is nil" do
-      let(:target) { Target.new(nil) }
+      let(:target) { SearchTarget.new(search_attr: nil) }
       let(:subject) { MatchNoAttribute.new(:search_attr) }
 
       it "is true" do
@@ -40,7 +40,7 @@ RSpec.describe MatchNoAttribute do
     end
 
     describe "if the target doesn't have the attribute" do
-      let(:target) { Target.new(rand) }
+      let(:target) { SearchTarget.new(search_attr: rand) }
       let(:subject) { MatchNoAttribute.new(:bad_attr) }
 
       it "is false" do

--- a/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
@@ -1,4 +1,5 @@
 require_relative "../../../../lib/query_string_search/abstract_matcher"
+require_relative "../../../doubles/search_target"
 
 RSpec.describe MatchNoAttribute do
   describe "match?" do

--- a/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
@@ -4,8 +4,8 @@ require_relative "../../../doubles/search_target"
 RSpec.describe MatchNoAttribute do
   describe "match?" do
     describe "if the target's attribute is not nil" do
-      let(:target) { SearchTarget.new(search_attr: "search_value") }
-      let(:subject) { MatchNoAttribute.new(:search_attr) }
+      let(:target) { SearchTarget.new(property: "search_value") }
+      let(:subject) { MatchNoAttribute.new(:property) }
 
       it "is false" do
         expect(subject.match?(target)).to be_falsey
@@ -13,8 +13,8 @@ RSpec.describe MatchNoAttribute do
     end
 
     describe "if the target's attribute is true" do
-      let(:target) { SearchTarget.new(search_attr: true) }
-      let(:subject) { MatchNoAttribute.new(:search_attr) }
+      let(:target) { SearchTarget.new(property: true) }
+      let(:subject) { MatchNoAttribute.new(:property) }
 
       it "is true" do
         expect(subject.match?(target)).to be_falsey
@@ -22,8 +22,8 @@ RSpec.describe MatchNoAttribute do
     end
 
     describe "if the target's attribute is false" do
-      let(:target) { SearchTarget.new(search_attr: false) }
-      let(:subject) { MatchNoAttribute.new(:search_attr) }
+      let(:target) { SearchTarget.new(property: false) }
+      let(:subject) { MatchNoAttribute.new(:property) }
 
       it "is true" do
         expect(subject.match?(target)).to be_truthy
@@ -31,8 +31,8 @@ RSpec.describe MatchNoAttribute do
     end
 
     describe "if the target's attribute is nil" do
-      let(:target) { SearchTarget.new(search_attr: nil) }
-      let(:subject) { MatchNoAttribute.new(:search_attr) }
+      let(:target) { SearchTarget.new(property: nil) }
+      let(:subject) { MatchNoAttribute.new(:property) }
 
       it "is true" do
         expect(subject.match?(target)).to be_truthy
@@ -40,7 +40,7 @@ RSpec.describe MatchNoAttribute do
     end
 
     describe "if the target doesn't have the attribute" do
-      let(:target) { SearchTarget.new(search_attr: rand) }
+      let(:target) { SearchTarget.new(property: rand) }
       let(:subject) { MatchNoAttribute.new(:bad_attr) }
 
       it "is false" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,5 +84,3 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
-
-Target = Struct.new(:search_attr)


### PR DESCRIPTION
Implements feature #2 

Thanks to the refactoring of `reserved_words`, implementing this was straight forward. Following the example of the existing course info extract, we are using `|` as our OR syntax. This could be a problem if someone wants to search for a attribute value that contains a `|`, but that issue is known: #1 
