### PR TITLE
Iw/feature/inequality comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ Returns every movie with a year of 1994
 
 Returns all movies with a year of 1994 or 1995
 
+### Return all data with values greater than or less than an attribute
+
+`movies?q=star_rating>1`
+Returns all movies with a star rating higher than one
+
+`movies?q=star_rating<3`
+Returns all movies with a star rating less than three
+
+`movies?q=star_rating>=2`
+Returns all movies with a star rating greater than or equal to 1
+
+`movies?q=star_rating<=4`
+Returns all movies with a star rating less than or equal to 4
+
 ### Combining Searches
 
 Search criteria can be separated with commas

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Returns all movies with a year of 1994 or 1995
 ### Return all data with values greater than or less than an attribute
 
 `movies?q=star_rating>1`
-Returns all movies with a star rating higher than one
+Returns all movies with a star rating greater than one
 
 `movies?q=star_rating<3`
 Returns all movies with a star rating less than three
 
 `movies?q=star_rating>=2`
-Returns all movies with a star rating greater than or equal to 1
+Returns all movies with a star rating greater than or equal to 2
 
 `movies?q=star_rating<=4`
 Returns all movies with a star rating less than or equal to 4

--- a/lib/query_string_search.rb
+++ b/lib/query_string_search.rb
@@ -4,7 +4,8 @@ module QueryStringSearch
   end
 
   class Search
-    attr_accessor :data_source, :query_string
+    attr_accessor :data_source
+    attr_reader :query_string
 
     def initialize(data_source, query_string)
       self.data_source = data_source
@@ -20,6 +21,10 @@ module QueryStringSearch
     end
 
     private
+
+    def query_string=(x)
+      @query_string = x ? CGI.unescape(x) : nil
+    end
 
     def filter_by_param(data, param)
       data.select { |c| param.match?(c) }

--- a/lib/query_string_search/abstract_matcher.rb
+++ b/lib/query_string_search/abstract_matcher.rb
@@ -14,11 +14,6 @@ module QueryStringSearch
       descendants.each_with_object([]) { |d, ret| ret << d.reserved_words }.flatten
     end
 
-    def initialize(attribute = nil, value = nil)
-      self.attribute = attribute
-      self.desired_value = value
-    end
-
     def match?(_)
       false
     end

--- a/lib/query_string_search/abstract_matcher.rb
+++ b/lib/query_string_search/abstract_matcher.rb
@@ -1,6 +1,6 @@
 module QueryStringSearch
   class AbstractMatcher
-    attr_accessor :attribute, :desired_value
+    attr_accessor :attribute, :desired_value, :operator
 
     def self.matchers
       descendants.push(self)

--- a/lib/query_string_search/abstract_matcher.rb
+++ b/lib/query_string_search/abstract_matcher.rb
@@ -27,7 +27,7 @@ module QueryStringSearch
       []
     end
 
-    def self.build_me?(_, _)
+    def self.build_me?(_)
       true
     end
 

--- a/lib/query_string_search/comparator.rb
+++ b/lib/query_string_search/comparator.rb
@@ -55,7 +55,13 @@ module QueryStringSearch
           equal?
         elsif operator == "∈"
           contain?
+        elsif ["<",">","<=",">="]
+          inequal?
         end
+      end
+
+      def inequal?
+        eval("#{other} #{operator} #{subject}")
       end
 
       def equal?

--- a/lib/query_string_search/comparator.rb
+++ b/lib/query_string_search/comparator.rb
@@ -1,18 +1,69 @@
 module QueryStringSearch
   module Comparator
-    def self.does(subject)
-      Comparison.new(subject)
+    def self.using(operator)
+      create_comparison
+      comparison.operator = operator
+      self
     end
 
-    class Comparison
-      attr_accessor :subject
+    def self.does(subject)
+      create_comparison
+      comparison.subject = subject
+      self
+    end
 
-      def initialize(subject)
-        self.subject = subject
+    def self.equal?(other)
+      comparison.operator = "="
+      compare_with?(other)
+    end
+
+    def self.contain?(other)
+      comparison.operator = "∈"
+      compare_with?(other)
+    end
+
+    def self.compare_with?(other)
+      comparison.other = other
+      resolve
+    end
+
+    private
+
+    def self.create_comparison
+      @comparison ||= Comparison.new
+    end
+
+    def self.comparison
+      @comparison
+    end
+
+    def self.resolve
+      ret = @comparison.compare
+      @comparison = nil
+      ret
+    end
+  end
+end
+
+module QueryStringSearch
+  module Comparator
+    class Comparison
+      attr_accessor :subject, :operator, :other
+
+      def compare
+        if operator == "="
+          equal?
+        elsif operator == "∈"
+          contain?
+        end
       end
 
-      def equal?(other)
+      def equal?
         normalize(subject) == normalize(other)
+      end
+
+      def contain?
+        normalize(subject).include?(normalize(other))
       end
 
       def normalize(unnormalized)
@@ -21,10 +72,6 @@ module QueryStringSearch
         else
           unnormalized.to_s.upcase
         end
-      end
-
-      def contain?(other)
-        normalize(subject).include?(normalize(other))
       end
     end
   end

--- a/lib/query_string_search/comparator.rb
+++ b/lib/query_string_search/comparator.rb
@@ -1,29 +1,31 @@
-module Comparator
-  def self.does(subject)
-    Comparison.new(subject)
-  end
-
-  class Comparison
-    attr_accessor :subject
-
-    def initialize(subject)
-      self.subject = subject
+module QueryStringSearch
+  module Comparator
+    def self.does(subject)
+      Comparison.new(subject)
     end
 
-    def equal?(other)
-      normalize(subject) == normalize(other)
-    end
+    class Comparison
+      attr_accessor :subject
 
-    def normalize(unnormalized)
-      if unnormalized.respond_to?(:each)
-        unnormalized.map(&:to_s).map(&:upcase)
-      else
-        unnormalized.to_s.upcase
+      def initialize(subject)
+        self.subject = subject
       end
-    end
 
-    def contain?(other)
-      normalize(subject).include?(normalize(other))
+      def equal?(other)
+        normalize(subject) == normalize(other)
+      end
+
+      def normalize(unnormalized)
+        if unnormalized.respond_to?(:each)
+          unnormalized.map(&:to_s).map(&:upcase)
+        else
+          unnormalized.to_s.upcase
+        end
+      end
+
+      def contain?(other)
+        normalize(subject).include?(normalize(other))
+      end
     end
   end
 end

--- a/lib/query_string_search/comparator.rb
+++ b/lib/query_string_search/comparator.rb
@@ -51,25 +51,31 @@ module QueryStringSearch
       attr_accessor :subject, :operator, :other
 
       def compare
-        if operator == "="
+        if ["=".to_sym].include?(operator)
           equal?
-        elsif operator == "∈"
+        elsif [:∈].include?(operator)
           contain?
-        elsif ["<",">","<=",">="]
+        elsif [:<, :>, :<=, :>=].include?(operator)
           inequal?
+        else
+          false
         end
       end
 
+      def operator=(x)
+        @operator = x.to_sym
+      end
+
       def inequal?
-        eval("#{other} #{operator} #{subject}")
+        other.to_i.public_send(operator, subject.to_i)
       end
 
       def equal?
-        normalize(subject) == normalize(other)
+        normalize(other).public_send(:==, normalize(subject))
       end
 
       def contain?
-        normalize(subject).include?(normalize(other))
+        normalize(subject).public_send(:&, [normalize(other)]).any?
       end
 
       def normalize(unnormalized)

--- a/lib/query_string_search/comparator.rb
+++ b/lib/query_string_search/comparator.rb
@@ -43,13 +43,15 @@ module QueryStringSearch
   module Comparator
     class ComparisonFactory
       def self.build(config)
-        if config.subject.respond_to?(:each)
-          SetComparison.new(config.subject, config.other)
-        elsif [:<, :>, :<=, :>=].include?(config.operator.to_sym)
-          InequalityComparison.new(config.subject, config.other, config.operator)
-        else
-          EqualityComparison.new(config.subject, config.other)
-        end
+        comparison = if config.subject.respond_to?(:each)
+                       SetComparison
+                     elsif [:<, :>, :<=, :>=].include?(config.operator.to_sym)
+                       InequalityComparison
+                     else
+                       EqualityComparison
+                     end
+
+        comparison.new(config.subject, config.other, config.operator.to_sym)
       end
     end
 

--- a/lib/query_string_search/matcher_factory.rb
+++ b/lib/query_string_search/matcher_factory.rb
@@ -1,7 +1,7 @@
 module QueryStringSearch
   class MatcherFactory
     def self.build(query_option, build_options)
-      constructor = build_options.detect { |m| m.build_me?(query_option.search_type, query_option.search_param) }
+      constructor = build_options.detect { |m| m.build_me?(query_option) }
 
       if constructor
         constructor.new(query_option.search_type, query_option.search_param)

--- a/lib/query_string_search/matcher_factory.rb
+++ b/lib/query_string_search/matcher_factory.rb
@@ -4,7 +4,10 @@ module QueryStringSearch
       matcher_to_build = build_options.detect { |m| m.build_me?(search_option) }
 
       if matcher_to_build
-        matcher_to_build.new(search_option.search_type, search_option.search_param)
+        matcher = matcher_to_build.new
+        matcher.attribute = search_option.search_type
+        matcher.desired_value = search_option.search_param
+        matcher
       end
     end
   end

--- a/lib/query_string_search/matcher_factory.rb
+++ b/lib/query_string_search/matcher_factory.rb
@@ -1,10 +1,10 @@
 module QueryStringSearch
   class MatcherFactory
     def self.build(search_option, build_options)
-      constructor = build_options.detect { |m| m.build_me?(search_option) }
+      matcher_to_build = build_options.detect { |m| m.build_me?(search_option) }
 
-      if constructor
-        constructor.new(search_option.search_type, search_option.search_param)
+      if matcher_to_build
+        matcher_to_build.new(search_option.search_type, search_option.search_param)
       end
     end
   end

--- a/lib/query_string_search/matcher_factory.rb
+++ b/lib/query_string_search/matcher_factory.rb
@@ -5,8 +5,8 @@ module QueryStringSearch
 
       if matcher_to_build
         matcher = matcher_to_build.new
-        matcher.attribute = search_option.search_type
-        matcher.desired_value = search_option.search_param
+        matcher.attribute = search_option.attribute
+        matcher.desired_value = search_option.desired_value
         matcher
       end
     end

--- a/lib/query_string_search/matcher_factory.rb
+++ b/lib/query_string_search/matcher_factory.rb
@@ -4,9 +4,10 @@ module QueryStringSearch
       matcher_to_build = build_options.detect { |m| m.build_me?(search_option) }
 
       if matcher_to_build
-        matcher = matcher_to_build.new
-        matcher.attribute = search_option.attribute
+        matcher               = matcher_to_build.new
+        matcher.attribute     = search_option.attribute
         matcher.desired_value = search_option.desired_value
+        matcher.operator      = search_option.operator
         matcher
       end
     end

--- a/lib/query_string_search/matcher_factory.rb
+++ b/lib/query_string_search/matcher_factory.rb
@@ -1,10 +1,10 @@
 module QueryStringSearch
   class MatcherFactory
-    def self.build(query_option, build_options)
-      constructor = build_options.detect { |m| m.build_me?(query_option) }
+    def self.build(search_option, build_options)
+      constructor = build_options.detect { |m| m.build_me?(search_option) }
 
       if constructor
-        constructor.new(query_option.search_type, query_option.search_param)
+        constructor.new(search_option.search_type, search_option.search_param)
       end
     end
   end

--- a/lib/query_string_search/matchers/match_all.rb
+++ b/lib/query_string_search/matchers/match_all.rb
@@ -4,6 +4,6 @@ class MatchAll < QueryStringSearch::AbstractMatcher
   end
 
   def self.build_me?(search_option)
-    search_option.search_type.nil? && search_option.search_param.nil?
+    search_option.attribute.nil? && search_option.desired_value.nil?
   end
 end

--- a/lib/query_string_search/matchers/match_all.rb
+++ b/lib/query_string_search/matchers/match_all.rb
@@ -3,7 +3,7 @@ class MatchAll < QueryStringSearch::AbstractMatcher
     true
   end
 
-  def self.build_me?(search_type, search_param)
-    search_type.nil? && search_param.nil?
+  def self.build_me?(search_option)
+    search_option.search_type.nil? && search_option.search_param.nil?
   end
 end

--- a/lib/query_string_search/matchers/match_attribute.rb
+++ b/lib/query_string_search/matchers/match_attribute.rb
@@ -10,7 +10,7 @@ class MatchAttribute < QueryStringSearch::AbstractMatcher
     ]
   end
 
-  def self.build_me?(_, search_param)
-    reserved_words.any? { |r| r.match(search_param) }
+  def self.build_me?(search_option)
+    reserved_words.any? { |r| r.match(search_option.search_param) }
   end
 end

--- a/lib/query_string_search/matchers/match_attribute.rb
+++ b/lib/query_string_search/matchers/match_attribute.rb
@@ -11,6 +11,6 @@ class MatchAttribute < QueryStringSearch::AbstractMatcher
   end
 
   def self.build_me?(search_option)
-    reserved_words.any? { |r| r.match(search_option.search_param) }
+    reserved_words.any? { |r| r.match(search_option.desired_value) }
   end
 end

--- a/lib/query_string_search/matchers/match_attribute_value.rb
+++ b/lib/query_string_search/matchers/match_attribute_value.rb
@@ -1,7 +1,7 @@
 class MatchAttributeValue < QueryStringSearch::AbstractMatcher
   def match?(data)
     match_with_contingency do
-      QueryStringSearch::Comparator.does(desired_value).equal?(actual_value(data))
+      QueryStringSearch::Comparator.using(operator).does(desired_value).compare_with?(actual_value(data))
     end
   end
 

--- a/lib/query_string_search/matchers/match_attribute_value.rb
+++ b/lib/query_string_search/matchers/match_attribute_value.rb
@@ -6,8 +6,8 @@ class MatchAttributeValue < QueryStringSearch::AbstractMatcher
   end
 
   def self.build_me?(search_option)
-    search_option.search_param &&
-      search_option.search_type &&
-      all_reserved_words.none? { |r| r.match(search_option.search_param) }
+    search_option.desired_value &&
+      search_option.attribute &&
+      all_reserved_words.none? { |r| r.match(search_option.desired_value) }
   end
 end

--- a/lib/query_string_search/matchers/match_attribute_value.rb
+++ b/lib/query_string_search/matchers/match_attribute_value.rb
@@ -5,9 +5,9 @@ class MatchAttributeValue < QueryStringSearch::AbstractMatcher
     end
   end
 
-  def self.build_me?(search_type, search_param)
-    search_param &&
-      search_type &&
-      all_reserved_words.none? { |r| r.match(search_param) }
+  def self.build_me?(search_option)
+    search_option.search_param &&
+      search_option.search_type &&
+      all_reserved_words.none? { |r| r.match(search_option.search_param) }
   end
 end

--- a/lib/query_string_search/matchers/match_attribute_value.rb
+++ b/lib/query_string_search/matchers/match_attribute_value.rb
@@ -1,7 +1,7 @@
 class MatchAttributeValue < QueryStringSearch::AbstractMatcher
   def match?(data)
     match_with_contingency do
-      Comparator.does(desired_value).equal?(actual_value(data))
+      QueryStringSearch::Comparator.does(desired_value).equal?(actual_value(data))
     end
   end
 

--- a/lib/query_string_search/matchers/match_multiple_attribute_values.rb
+++ b/lib/query_string_search/matchers/match_multiple_attribute_values.rb
@@ -16,6 +16,6 @@ class MatchMultipleAttributeValues < QueryStringSearch::AbstractMatcher
   end
 
   def self.build_me?(search_option)
-    reserved_words.any? { |r| r.match(search_option.search_param) }
+    reserved_words.any? { |r| r.match(search_option.desired_value) }
   end
 end

--- a/lib/query_string_search/matchers/match_multiple_attribute_values.rb
+++ b/lib/query_string_search/matchers/match_multiple_attribute_values.rb
@@ -1,7 +1,7 @@
 class MatchMultipleAttributeValues < QueryStringSearch::AbstractMatcher
   def match?(data)
     match_with_contingency do
-      Comparator.does(desired_value).contain?(actual_value(data))
+      QueryStringSearch::Comparator.does(desired_value).contain?(actual_value(data))
     end
   end
 

--- a/lib/query_string_search/matchers/match_multiple_attribute_values.rb
+++ b/lib/query_string_search/matchers/match_multiple_attribute_values.rb
@@ -15,7 +15,7 @@ class MatchMultipleAttributeValues < QueryStringSearch::AbstractMatcher
     super(x.split("|"))
   end
 
-  def self.build_me?(_, search_param)
-    reserved_words.any? { |r| r.match(search_param) }
+  def self.build_me?(search_option)
+    reserved_words.any? { |r| r.match(search_option.search_param) }
   end
 end

--- a/lib/query_string_search/matchers/match_no_attribute.rb
+++ b/lib/query_string_search/matchers/match_no_attribute.rb
@@ -11,6 +11,6 @@ class MatchNoAttribute < QueryStringSearch::AbstractMatcher
   end
 
   def self.build_me?(search_option)
-    reserved_words.any? { |r| r.match(search_option.search_param) }
+    reserved_words.any? { |r| r.match(search_option.desired_value) }
   end
 end

--- a/lib/query_string_search/matchers/match_no_attribute.rb
+++ b/lib/query_string_search/matchers/match_no_attribute.rb
@@ -10,7 +10,7 @@ class MatchNoAttribute < QueryStringSearch::AbstractMatcher
     ]
   end
 
-  def self.build_me?(_, search_param)
-    reserved_words.any? { |r| r.match(search_param) }
+  def self.build_me?(search_option)
+    reserved_words.any? { |r| r.match(search_option.search_param) }
   end
 end

--- a/lib/query_string_search/search_option.rb
+++ b/lib/query_string_search/search_option.rb
@@ -1,0 +1,22 @@
+module QueryStringSearch
+  class SearchOption
+    attr_reader :search_type, :search_param, :operator
+
+    def initialize(raw_query)
+      parsed_query = /(?<attribute>\w+)(?<operator>\W+)(?<value>.+)/.match(raw_query)
+      if parsed_query
+        self.search_type  = parsed_query[:attribute]
+        self.search_param = parsed_query[:value]
+        self.operator     = parsed_query[:operator]
+      end
+    end
+
+    def search_type
+      @search_type ? @search_type.to_sym : nil
+    end
+
+    private
+
+    attr_writer :search_type, :search_param, :operator
+  end
+end

--- a/lib/query_string_search/search_option.rb
+++ b/lib/query_string_search/search_option.rb
@@ -1,22 +1,22 @@
 module QueryStringSearch
   class SearchOption
-    attr_reader :search_type, :search_param, :operator
+    attr_reader :attribute, :desired_value, :operator
 
     def initialize(raw_query)
       parsed_query = /(?<attribute>\w+)(?<operator>\W+)(?<value>.+)/.match(raw_query)
       if parsed_query
-        self.search_type  = parsed_query[:attribute]
-        self.search_param = parsed_query[:value]
-        self.operator     = parsed_query[:operator]
+        self.attribute     = parsed_query[:attribute]
+        self.desired_value = parsed_query[:value]
+        self.operator      = parsed_query[:operator]
       end
     end
 
-    def search_type
-      @search_type ? @search_type.to_sym : nil
+    def attribute
+      @attribute ? @attribute.to_sym : nil
     end
 
     private
 
-    attr_writer :search_type, :search_param, :operator
+    attr_writer :attribute, :desired_value, :operator
   end
 end

--- a/lib/query_string_search/search_option.rb
+++ b/lib/query_string_search/search_option.rb
@@ -3,12 +3,10 @@ module QueryStringSearch
     attr_reader :attribute, :desired_value, :operator
 
     def initialize(raw_query)
-      parsed_query = /(?<attribute>\w+)(?<operator>\W+)(?<value>.+)/.match(raw_query)
-      if parsed_query
-        self.attribute     = parsed_query[:attribute]
-        self.desired_value = parsed_query[:value]
-        self.operator      = parsed_query[:operator]
-      end
+      parsed_query       = KeyValue.parse(raw_query)
+      self.attribute     = parsed_query.attribute
+      self.desired_value = parsed_query.desired_value
+      self.operator      = parsed_query.operator
     end
 
     def attribute
@@ -18,5 +16,20 @@ module QueryStringSearch
     private
 
     attr_writer :attribute, :desired_value, :operator
+  end
+
+  class KeyValue
+    attr_accessor :attribute, :desired_value, :operator
+
+    def self.parse(raw_query)
+      new(/(?<attribute>\w+)(?<operator>\W+)(?<desired_value>.+)/.match(raw_query))
+    end
+
+    def initialize(match_data)
+      match_data = match_data ? match_data : {}
+      self.attribute = match_data[:attribute]
+      self.desired_value = match_data[:desired_value]
+      self.operator = match_data[:operator]
+    end
   end
 end

--- a/lib/query_string_search/search_option.rb
+++ b/lib/query_string_search/search_option.rb
@@ -26,10 +26,10 @@ module QueryStringSearch
     end
 
     def initialize(match_data)
-      match_data = match_data ? match_data : {}
-      self.attribute = match_data[:attribute]
+      match_data         = match_data ? match_data : {}
+      self.attribute     = match_data[:attribute]
       self.desired_value = match_data[:desired_value]
-      self.operator = match_data[:operator]
+      self.operator      = match_data[:operator]
     end
   end
 end

--- a/lib/query_string_search/search_options.rb
+++ b/lib/query_string_search/search_options.rb
@@ -1,6 +1,6 @@
 module QueryStringSearch
   class SearchOptions
-    attr_reader :search_type, :search_param
+    attr_reader :search_type, :search_param, :operator
 
     def self.parse(query_string)
       if query_string
@@ -14,7 +14,12 @@ module QueryStringSearch
     end
 
     def initialize(raw_query)
-      self.search_type, self.search_param = raw_query.to_s.split("=")
+      parsed_query = /(?<attribute>\w+)(?<operator>\W+)(?<value>.+)/.match(raw_query)
+      if parsed_query
+        self.search_type  = parsed_query[:attribute]
+        self.search_param = parsed_query[:value]
+        self.operator     = parsed_query[:operator]
+      end
     end
 
     def search_type
@@ -23,6 +28,6 @@ module QueryStringSearch
 
     private
 
-    attr_writer :search_type, :search_param
+    attr_writer :search_type, :search_param, :operator
   end
 end

--- a/lib/query_string_search/search_options.rb
+++ b/lib/query_string_search/search_options.rb
@@ -2,8 +2,7 @@ module QueryStringSearch
   module SearchOptions
     def self.parse(query_string)
       if query_string
-        search_params = query_string.split(",")
-        search_params.each_with_object([]) do |p, ret|
+        query_string.split(",").each_with_object([]) do |p, ret|
           ret << QueryStringSearch::SearchOption.new(p)
         end
       else

--- a/lib/query_string_search/search_options.rb
+++ b/lib/query_string_search/search_options.rb
@@ -1,33 +1,14 @@
 module QueryStringSearch
-  class SearchOptions
-    attr_reader :search_type, :search_param, :operator
-
+  module SearchOptions
     def self.parse(query_string)
       if query_string
         search_params = query_string.split(",")
         search_params.each_with_object([]) do |p, ret|
-          ret << new(p)
+          ret << QueryStringSearch::SearchOption.new(p)
         end
       else
-        [new(nil)]
+        [QueryStringSearch::SearchOption.new(nil)]
       end
     end
-
-    def initialize(raw_query)
-      parsed_query = /(?<attribute>\w+)(?<operator>\W+)(?<value>.+)/.match(raw_query)
-      if parsed_query
-        self.search_type  = parsed_query[:attribute]
-        self.search_param = parsed_query[:value]
-        self.operator     = parsed_query[:operator]
-      end
-    end
-
-    def search_type
-      @search_type ? @search_type.to_sym : nil
-    end
-
-    private
-
-    attr_writer :search_type, :search_param, :operator
   end
 end

--- a/lib/query_string_search/search_options.rb
+++ b/lib/query_string_search/search_options.rb
@@ -21,10 +21,6 @@ module QueryStringSearch
       @search_type ? @search_type.to_sym : nil
     end
 
-    def search_param
-      @search_param ? CGI.unescape(@search_param) : @search_param
-    end
-
     private
 
     attr_writer :search_type, :search_param

--- a/lib/query_string_search/search_parameters.rb
+++ b/lib/query_string_search/search_parameters.rb
@@ -5,13 +5,13 @@ module QueryStringSearch
     def_delegators :@collection, :each
 
     def self.build_from_querystring(query_string, factory = QueryStringSearch::MatcherFactory, matchers = QueryStringSearch::AbstractMatcher.matchers)
-      parameters = QueryStringSearch::SearchOptions.parse(query_string)
-      new(parameters, factory, matchers)
+      search_options = QueryStringSearch::SearchOptions.parse(query_string)
+      new(search_options, factory, matchers)
     end
 
-    def initialize(parameters, factory, matchers)
-      parameters.each do |param|
-        collection << factory.build(param, matchers)
+    def initialize(search_options, factory, matchers)
+      search_options.each do |search_option|
+        collection << factory.build(search_option, matchers)
       end
     end
 

--- a/spec/features/find_records_with_inequality_matchers_spec.rb
+++ b/spec/features/find_records_with_inequality_matchers_spec.rb
@@ -1,0 +1,49 @@
+require_relative "../../lib/query_string_search"
+require_relative "../fixtures/movie"
+
+RSpec.describe "Finding data with inequality matchers" do
+
+  describe "Allows searching for values greater than a number" do
+    let(:data_set) { Movie.random_collection }
+    let(:movies_with_more_than_one_star) { data_set.select { |d| d.star_rating > 1 } }
+
+    it "Returns records that match the requested value" do
+      results = QueryStringSearch.new(data_set, "star_rating>1").results
+
+      expect(results).to eq(movies_with_more_than_one_star)
+    end
+  end
+
+  describe "Allows searching for values less than a number" do
+    let(:data_set) { Movie.random_collection }
+    let(:movies_with_fewer_than_three_stars) { data_set.select { |d| d.star_rating < 3 } }
+
+    it "Returns records that match the requested value" do
+      results = QueryStringSearch.new(data_set, "star_rating<3").results
+
+      expect(results).to eq(movies_with_more_than_one_star)
+    end
+  end
+
+  describe "Allows searching for values greater than or equal to a number" do
+    let(:data_set) { Movie.random_collection }
+    let(:movies_with_two_or_more_stars) { data_set.select { |d| d.star_rating >= 2 } }
+
+    it "Returns records that match the requested value" do
+      results = QueryStringSearch.new(data_set, "star_rating>=2").results
+
+      expect(results).to eq(movies_with_more_than_one_star)
+    end
+  end
+
+  describe "Allows searching for values less than or equal to a number" do
+    let(:data_set) { Movie.random_collection }
+    let(:movies_with_four_or_fewer_stars) { data_set.select { |d| d.star_rating <= 4 } }
+
+    it "Returns records that match the requested value" do
+      results = QueryStringSearch.new(data_set, "star_rating<=4").results
+
+      expect(results).to eq(movies_with_more_than_one_star)
+    end
+  end
+end

--- a/spec/features/find_records_with_inequality_matchers_spec.rb
+++ b/spec/features/find_records_with_inequality_matchers_spec.rb
@@ -2,7 +2,6 @@ require_relative "../../lib/query_string_search"
 require_relative "../fixtures/movie"
 
 RSpec.describe "Finding data with inequality matchers" do
-
   describe "Allows searching for values greater than a number" do
     let(:data_set) { Movie.random_collection }
     let(:movies_with_more_than_one_star) { data_set.select { |d| d.star_rating > 1 } }

--- a/spec/features/find_records_with_inequality_matchers_spec.rb
+++ b/spec/features/find_records_with_inequality_matchers_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Finding data with inequality matchers" do
     it "Returns records that match the requested value" do
       results = QueryStringSearch.new(data_set, "star_rating<3").results
 
-      expect(results).to eq(movies_with_more_than_one_star)
+      expect(results).to eq(movies_with_fewer_than_three_stars)
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe "Finding data with inequality matchers" do
     it "Returns records that match the requested value" do
       results = QueryStringSearch.new(data_set, "star_rating>=2").results
 
-      expect(results).to eq(movies_with_more_than_one_star)
+      expect(results).to eq(movies_with_two_or_more_stars)
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe "Finding data with inequality matchers" do
     it "Returns records that match the requested value" do
       results = QueryStringSearch.new(data_set, "star_rating<=4").results
 
-      expect(results).to eq(movies_with_more_than_one_star)
+      expect(results).to eq(movies_with_four_or_fewer_stars)
     end
   end
 end

--- a/spec/fixtures/movie.rb
+++ b/spec/fixtures/movie.rb
@@ -1,7 +1,7 @@
 class Movie
   attr_accessor :title, :rating, :year, :country, :seen, :star_rating
 
-  def self.random_collection(count = 1_000)
+  def self.random_collection(count = 100)
     (1...count).map { |_| Movie.random }
   end
 

--- a/spec/fixtures/movie.rb
+++ b/spec/fixtures/movie.rb
@@ -2,17 +2,19 @@ class Movie
   attr_accessor :title, :rating, :year, :country, :seen, :star_rating
 
   def self.random_collection(count = 1_000)
-    (1...count).inject([]) do |collection, _|
-      collection << Movie.new(random_title, random_rating, random_year, random_country)
-    end
+    (1...count).map { |_| Movie.random }
   end
 
-  def initialize(title, rating, year, country)
-    self.title   = title
-    self.rating  = rating
-    self.year    = year
-    self.country = country
-    self.seen    = [true, false].sample
+  def self.random
+    Movie.new
+  end
+
+  def initialize
+    self.title       = random_title
+    self.rating      = random_rating
+    self.year        = random_year
+    self.country     = random_country
+    self.seen        = [true, false].sample
     self.star_rating = [1, 2, 3, 4, 5].sample
   end
 
@@ -20,19 +22,19 @@ class Movie
     seen
   end
 
-  def self.random_title
+  def random_title
     "Random Movie #{rand(10_000)}"
   end
 
-  def self.random_rating
+  def random_rating
     ["X", "NC-17", "R", "PG-13", "PG", "G", nil].sample
   end
 
-  def self.random_year
+  def random_year
     (1990..2014).to_a.sample.to_s
   end
 
-  def self.random_country
+  def random_country
     %w(
       US CAN UK HK BR RUS FR IN
     ).sample

--- a/spec/fixtures/movie.rb
+++ b/spec/fixtures/movie.rb
@@ -1,5 +1,5 @@
 class Movie
-  attr_accessor :title, :rating, :year, :country, :seen
+  attr_accessor :title, :rating, :year, :country, :seen, :star_rating
 
   def self.random_collection(count = 1_000)
     (1...count).inject([]) do |collection, _|
@@ -13,6 +13,7 @@ class Movie
     self.year    = year
     self.country = country
     self.seen    = [true, false].sample
+    self.star_rating = [1, 2, 3, 4, 5].sample
   end
 
   def seen?

--- a/spec/lib/query_string_search/abstract_matcher_spec.rb
+++ b/spec/lib/query_string_search/abstract_matcher_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe QueryStringSearch::AbstractMatcher do
       it = QueryStringSearch::AbstractMatcher.new
       it.attribute = :other
       it.desired_value = value
+      it.operator = "="
       expect(it.match?(target)).to be_falsey
     end
   end

--- a/spec/lib/query_string_search/abstract_matcher_spec.rb
+++ b/spec/lib/query_string_search/abstract_matcher_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe QueryStringSearch::AbstractMatcher do
     it "is false" do
       value = rand
       target = OpenStruct.new(other: value)
-      it = QueryStringSearch::AbstractMatcher.new(:other, value)
+      it = QueryStringSearch::AbstractMatcher.new
+      it.attribute = :other
+      it.desired_value = value
       expect(it.match?(target)).to be_falsey
     end
   end

--- a/spec/lib/query_string_search/abstract_matcher_spec.rb
+++ b/spec/lib/query_string_search/abstract_matcher_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe QueryStringSearch::AbstractMatcher do
 
   describe "build_me?" do
     it "is true" do
-      it = QueryStringSearch::AbstractMatcher.build_me?(rand, rand)
+      it = QueryStringSearch::AbstractMatcher.build_me?(Object.new)
       expect(it).to be_truthy
     end
   end

--- a/spec/lib/query_string_search/comparator_spec.rb
+++ b/spec/lib/query_string_search/comparator_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe QueryStringSearch::Comparator do
     end
 
     describe "Using the equal? alias" do
-        it "returns true if the values are equal?" do
-          value = rand
-          comparison = QueryStringSearch::Comparator.does(value).equal?(value)
-          expect(comparison).to be_truthy
-        end
+      it "returns true if the values are equal?" do
+        value = rand
+        comparison = QueryStringSearch::Comparator.does(value).equal?(value)
+        expect(comparison).to be_truthy
+      end
     end
   end
 

--- a/spec/lib/query_string_search/comparator_spec.rb
+++ b/spec/lib/query_string_search/comparator_spec.rb
@@ -21,6 +21,45 @@ RSpec.describe QueryStringSearch::Comparator do
     end
   end
 
+  describe "inequality" do
+    describe "compare_with?" do
+      let(:lower_value) { "2" }
+      let(:higher_value) { "3" }
+
+      it "handles > operator comparisons" do
+        comparison = QueryStringSearch::Comparator.using(">").does(lower_value).compare_with?(higher_value)
+        expect(comparison).to be_truthy
+
+        comparison = QueryStringSearch::Comparator.using(">").does(higher_value).compare_with?(lower_value)
+        expect(comparison).to be_falsey
+      end
+
+      it "handles < operator comparisons" do
+        comparison = QueryStringSearch::Comparator.using("<").does(lower_value).compare_with?(higher_value)
+        expect(comparison).to be_falsey
+
+        comparison = QueryStringSearch::Comparator.using("<").does(higher_value).compare_with?(lower_value)
+        expect(comparison).to be_truthy
+      end
+
+      it "handles >= operator comparisons" do
+        comparison = QueryStringSearch::Comparator.using(">=").does(lower_value).compare_with?(lower_value)
+        expect(comparison).to be_truthy
+
+        comparison = QueryStringSearch::Comparator.using(">=").does(higher_value).compare_with?(lower_value)
+        expect(comparison).to be_falsey
+      end
+
+      it "handles <= operator comparisons" do
+        comparison = QueryStringSearch::Comparator.using("<=").does(lower_value).compare_with?(lower_value)
+        expect(comparison).to be_truthy
+
+        comparison = QueryStringSearch::Comparator.using("<=").does(lower_value).compare_with?(higher_value)
+        expect(comparison).to be_falsey
+      end
+    end
+  end
+
   describe "member of" do
     describe "Using the ∈ operator" do
       describe "compare_with?" do

--- a/spec/lib/query_string_search/comparator_spec.rb
+++ b/spec/lib/query_string_search/comparator_spec.rb
@@ -1,0 +1,45 @@
+require_relative "../../../lib/query_string_search/comparator"
+
+RSpec.describe QueryStringSearch::Comparator do
+  describe "equality" do
+    describe "Using an equality operator" do
+      describe "compare_with?" do
+        it "returns true if the values are equal?" do
+          value = rand
+          comparison = QueryStringSearch::Comparator.using("=").does(value).compare_with?(value)
+          expect(comparison).to be_truthy
+        end
+      end
+    end
+
+    describe "Using the equal? alias" do
+        it "returns true if the values are equal?" do
+          value = rand
+          comparison = QueryStringSearch::Comparator.does(value).equal?(value)
+          expect(comparison).to be_truthy
+        end
+    end
+  end
+
+  describe "member of" do
+    describe "Using the ∈ operator" do
+      describe "compare_with?" do
+        it "returns true if the values is a member of the collection" do
+          set = [1, 2, 3]
+          value = set.sample
+          comparison = QueryStringSearch::Comparator.using("∈").does(set).compare_with?(value)
+          expect(comparison).to be_truthy
+        end
+      end
+    end
+
+    describe "Using the contain? alias" do
+      it "returns true if the values is a member of the collection" do
+        set = [1, 2, 3]
+        value = set.sample
+        comparison = QueryStringSearch::Comparator.does(set).contain?(value)
+        expect(comparison).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/lib/query_string_search/comparator_spec.rb
+++ b/spec/lib/query_string_search/comparator_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe QueryStringSearch::Comparator do
         it "returns true if the values is a member of the collection" do
           set = [1, 2, 3]
           value = set.sample
-          comparison = QueryStringSearch::Comparator.using("∈").does(set).compare_with?(value)
+          comparison = QueryStringSearch::Comparator.using("&").does(set).compare_with?(value)
           expect(comparison).to be_truthy
         end
       end

--- a/spec/lib/query_string_search/matcher_factory_spec.rb
+++ b/spec/lib/query_string_search/matcher_factory_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe QueryStringSearch::MatcherFactory do
   before do
     allow(param_double).to receive(:desired_value).and_return("test_search_value")
     allow(param_double).to receive(:attribute).and_return("test_search_attribute")
+    allow(param_double).to receive(:operator).and_return("test_operator")
   end
 
   describe "build" do
@@ -17,6 +18,7 @@ RSpec.describe QueryStringSearch::MatcherFactory do
         test_return = instance_double(QueryStringSearch::AbstractMatcher.matchers.sample)
         expect(test_return).to receive(:attribute=).with("test_search_attribute")
         expect(test_return).to receive(:desired_value=).with("test_search_value")
+        expect(test_return).to receive(:operator=).with("test_operator")
 
         expect(matcher_double).to receive(:build_me?).with(param_double).and_return(true)
         expect(matcher_double).to receive(:new).and_return(test_return)

--- a/spec/lib/query_string_search/matcher_factory_spec.rb
+++ b/spec/lib/query_string_search/matcher_factory_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe QueryStringSearch::MatcherFactory do
     describe "finds a matcher to build" do
       it "builds that matcher and returns it" do
         test_return = Object.new
-        expect(matcher_double).to receive(:build_me?).with(param_double.search_type, param_double.search_param).and_return(true)
+        expect(matcher_double).to receive(:build_me?).with(param_double).and_return(true)
         expect(matcher_double).to receive(:new).with(param_double.search_type, param_double.search_param).and_return(test_return)
         expect(QueryStringSearch::MatcherFactory.build(param_double, build_candidates)).to eq(test_return)
       end

--- a/spec/lib/query_string_search/matcher_factory_spec.rb
+++ b/spec/lib/query_string_search/matcher_factory_spec.rb
@@ -13,10 +13,13 @@ RSpec.describe QueryStringSearch::MatcherFactory do
 
   describe "build" do
     describe "finds a matcher to build" do
-      it "builds that matcher and returns it" do
-        test_return = Object.new
+      it "builds that matcher, configures and returns it" do
+        test_return = instance_double(QueryStringSearch::AbstractMatcher.matchers.sample)
+        expect(test_return).to receive(:attribute=).with("test_search_type")
+        expect(test_return).to receive(:desired_value=).with("test_search_param")
+
         expect(matcher_double).to receive(:build_me?).with(param_double).and_return(true)
-        expect(matcher_double).to receive(:new).with(param_double.search_type, param_double.search_param).and_return(test_return)
+        expect(matcher_double).to receive(:new).and_return(test_return)
         expect(QueryStringSearch::MatcherFactory.build(param_double, build_candidates)).to eq(test_return)
       end
     end

--- a/spec/lib/query_string_search/matcher_factory_spec.rb
+++ b/spec/lib/query_string_search/matcher_factory_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe QueryStringSearch::MatcherFactory do
   let(:build_candidates) { [matcher_double] }
 
   before do
-    allow(param_double).to receive(:search_param).and_return("test_search_param")
-    allow(param_double).to receive(:search_type).and_return("test_search_type")
+    allow(param_double).to receive(:desired_value).and_return("test_search_value")
+    allow(param_double).to receive(:attribute).and_return("test_search_attribute")
   end
 
   describe "build" do
     describe "finds a matcher to build" do
       it "builds that matcher, configures and returns it" do
         test_return = instance_double(QueryStringSearch::AbstractMatcher.matchers.sample)
-        expect(test_return).to receive(:attribute=).with("test_search_type")
-        expect(test_return).to receive(:desired_value=).with("test_search_param")
+        expect(test_return).to receive(:attribute=).with("test_search_attribute")
+        expect(test_return).to receive(:desired_value=).with("test_search_value")
 
         expect(matcher_double).to receive(:build_me?).with(param_double).and_return(true)
         expect(matcher_double).to receive(:new).and_return(test_return)

--- a/spec/lib/query_string_search/matchers/match_all_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_all_spec.rb
@@ -9,17 +9,30 @@ RSpec.describe MatchAll do
   end
 
   describe "build_me?" do
+    let(:search_option) { instance_double(QueryStringSearch::SearchOption) }
+
     describe "given a nil search_type and search_param" do
       it "is true" do
-        expect(MatchAll.build_me?(nil, nil)).to be_truthy
+        allow(search_option).to receive(:search_type).and_return(nil)
+        allow(search_option).to receive(:search_param).and_return(nil)
+
+        expect(MatchAll.build_me?(search_option)).to be_truthy
       end
     end
 
     describe "given a non-nil search_type or search_param" do
       it "is false" do
-        expect(MatchAll.build_me?(rand, nil)).to be_falsey
-        expect(MatchAll.build_me?(nil, rand)).to be_falsey
-        expect(MatchAll.build_me?(rand, rand)).to be_falsey
+        allow(search_option).to receive(:search_type).and_return(rand)
+        allow(search_option).to receive(:search_param).and_return(nil)
+        expect(MatchAll.build_me?(search_option)).to be_falsey
+
+        allow(search_option).to receive(:search_type).and_return(nil)
+        allow(search_option).to receive(:search_param).and_return(rand)
+        expect(MatchAll.build_me?(search_option)).to be_falsey
+
+        allow(search_option).to receive(:search_type).and_return(rand)
+        allow(search_option).to receive(:search_param).and_return(rand)
+        expect(MatchAll.build_me?(search_option)).to be_falsey
       end
     end
   end

--- a/spec/lib/query_string_search/matchers/match_all_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_all_spec.rb
@@ -13,27 +13,27 @@ RSpec.describe MatchAll do
   describe "build_me?" do
     let(:search_option) { instance_double(QueryStringSearch::SearchOption) }
 
-    describe "given a nil search_type and search_param" do
+    describe "given a nil attribute and desired_value" do
       it "is true" do
-        allow(search_option).to receive(:search_type).and_return(nil)
-        allow(search_option).to receive(:search_param).and_return(nil)
+        allow(search_option).to receive(:attribute).and_return(nil)
+        allow(search_option).to receive(:desired_value).and_return(nil)
 
         expect(MatchAll.build_me?(search_option)).to be_truthy
       end
     end
 
-    describe "given a non-nil search_type or search_param" do
+    describe "given a non-nil attribute or desired_value" do
       it "is false" do
-        allow(search_option).to receive(:search_type).and_return(rand)
-        allow(search_option).to receive(:search_param).and_return(nil)
+        allow(search_option).to receive(:attribute).and_return(rand)
+        allow(search_option).to receive(:desired_value).and_return(nil)
         expect(MatchAll.build_me?(search_option)).to be_falsey
 
-        allow(search_option).to receive(:search_type).and_return(nil)
-        allow(search_option).to receive(:search_param).and_return(rand)
+        allow(search_option).to receive(:attribute).and_return(nil)
+        allow(search_option).to receive(:desired_value).and_return(rand)
         expect(MatchAll.build_me?(search_option)).to be_falsey
 
-        allow(search_option).to receive(:search_type).and_return(rand)
-        allow(search_option).to receive(:search_param).and_return(rand)
+        allow(search_option).to receive(:attribute).and_return(rand)
+        allow(search_option).to receive(:desired_value).and_return(rand)
         expect(MatchAll.build_me?(search_option)).to be_falsey
       end
     end

--- a/spec/lib/query_string_search/matchers/match_all_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_all_spec.rb
@@ -3,7 +3,9 @@ require_relative "../../../../lib/query_string_search/abstract_matcher"
 RSpec.describe MatchAll do
   describe "match?" do
     it "is true" do
-      it = MatchAll.new(:other, rand)
+      it = MatchAll.new
+      it.attribute = :other
+      it.desired_value = rand
       expect(it.match?(rand)).to be_truthy
     end
   end

--- a/spec/lib/query_string_search/matchers/match_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_spec.rb
@@ -5,46 +5,51 @@ RSpec.describe MatchAttribute do
   describe "match?" do
     describe "if the target's attribute is not nil" do
       let(:target) { SearchTarget.new(property: "search_value") }
-      let(:subject) { MatchAttribute.new(:property) }
 
       it "is true" do
-        expect(subject.match?(target)).to be_truthy
+        matcher = MatchAttribute.new
+        matcher.attribute = :property
+        expect(matcher.match?(target)).to be_truthy
       end
     end
 
     describe "if the target's attribute is true" do
       let(:target) { SearchTarget.new(property: true) }
-      let(:subject) { MatchAttribute.new(:property) }
 
       it "is true" do
-        expect(subject.match?(target)).to be_truthy
+        matcher = MatchAttribute.new
+        matcher.attribute = :property
+        expect(matcher.match?(target)).to be_truthy
       end
     end
 
     describe "if the target's attribute is nil" do
       let(:target) { SearchTarget.new(property: nil) }
-      let(:subject) { MatchAttribute.new(:property) }
 
       it "is false" do
-        expect(subject.match?(target)).to be_falsey
+        matcher = MatchAttribute.new
+        matcher.attribute = :property
+        expect(matcher.match?(target)).to be_falsey
       end
     end
 
     describe "if the target's attribute is false" do
       let(:target) { SearchTarget.new(property: false) }
-      let(:subject) { MatchAttribute.new(:property) }
 
       it "is true" do
-        expect(subject.match?(target)).to be_falsey
+        matcher = MatchAttribute.new
+        matcher.attribute = :property
+        expect(matcher.match?(target)).to be_falsey
       end
     end
 
     describe "if the target doesn't have the attribute" do
       let(:target) { SearchTarget.new(property: rand) }
-      let(:subject) { MatchAttribute.new(:bad_attr) }
 
       it "is false" do
-        expect(subject.match?(target)).to be_falsey
+        matcher = MatchAttribute.new
+        matcher.attribute = :bat_attr
+        expect(matcher.match?(target)).to be_falsey
       end
     end
   end

--- a/spec/lib/query_string_search/matchers/match_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_spec.rb
@@ -57,19 +57,19 @@ RSpec.describe MatchAttribute do
   describe "build_me?" do
     let(:search_option) { instance_double(QueryStringSearch::SearchOption) }
 
-    describe "given a search param of 'all' or 'true'" do
+    describe "given a value of 'all' or 'true'" do
       it "is true" do
-        %w(all true).each do |search_param|
-          allow(search_option).to receive(:search_param).and_return(search_param)
+        %w(all true).each do |desired_value|
+          allow(search_option).to receive(:desired_value).and_return(desired_value)
           expect(MatchAttribute.build_me?(search_option)).to be_truthy
         end
       end
     end
 
-    describe "given a search param that is not 'all' or 'true'" do
+    describe "given a value that is not 'all' or 'true'" do
       it "is false" do
-        %w(1all rue).each do |search_param|
-          allow(search_option).to receive(:search_param).and_return(search_param)
+        %w(1all rue).each do |desired_value|
+          allow(search_option).to receive(:desired_value).and_return(desired_value)
           expect(MatchAttribute.build_me?(search_option)).to be_falsey
         end
       end

--- a/spec/lib/query_string_search/matchers/match_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_spec.rb
@@ -50,10 +50,13 @@ RSpec.describe MatchAttribute do
   end
 
   describe "build_me?" do
+    let(:search_option) { instance_double(QueryStringSearch::SearchOption) }
+
     describe "given a search param of 'all' or 'true'" do
       it "is true" do
         %w(all true).each do |search_param|
-          expect(MatchAttribute.build_me?(rand, search_param)).to be_truthy
+          allow(search_option).to receive(:search_param).and_return(search_param)
+          expect(MatchAttribute.build_me?(search_option)).to be_truthy
         end
       end
     end
@@ -61,7 +64,8 @@ RSpec.describe MatchAttribute do
     describe "given a search param that is not 'all' or 'true'" do
       it "is false" do
         %w(1all rue).each do |search_param|
-          expect(MatchAttribute.build_me?(rand, search_param)).to be_falsey
+          allow(search_option).to receive(:search_param).and_return(search_param)
+          expect(MatchAttribute.build_me?(search_option)).to be_falsey
         end
       end
     end

--- a/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
@@ -41,17 +41,29 @@ RSpec.describe MatchAttributeValue do
   end
 
   describe "build_me?" do
+    let(:search_option) { instance_double(QueryStringSearch::SearchOption) }
+
     describe "given a non-nil search_type and search_param" do
       it "is true" do
-        expect(MatchAttributeValue.build_me?(rand.to_s, rand.to_s)).to be_truthy
+        allow(search_option).to receive(:search_type).and_return(rand.to_s)
+        allow(search_option).to receive(:search_param).and_return(rand.to_s)
+        expect(MatchAttributeValue.build_me?(search_option)).to be_truthy
       end
     end
 
     describe "given a nil search_type or search_param" do
       it "is false" do
-        expect(MatchAttributeValue.build_me?(rand.to_s, nil)).to be_falsey
-        expect(MatchAttributeValue.build_me?(nil, rand.to_s)).to be_falsey
-        expect(MatchAttributeValue.build_me?(nil, nil)).to be_falsey
+        allow(search_option).to receive(:search_type).and_return(rand.to_s)
+        allow(search_option).to receive(:search_param).and_return(nil)
+        expect(MatchAttributeValue.build_me?(search_option)).to be_falsey
+
+        allow(search_option).to receive(:search_type).and_return(nil)
+        allow(search_option).to receive(:search_param).and_return(rand.to_s)
+        expect(MatchAttributeValue.build_me?(search_option)).to be_falsey
+
+        allow(search_option).to receive(:search_type).and_return(nil)
+        allow(search_option).to receive(:search_param).and_return(nil)
+        expect(MatchAttributeValue.build_me?(search_option)).to be_falsey
       end
     end
   end

--- a/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
@@ -5,37 +5,45 @@ RSpec.describe MatchAttributeValue do
   describe "match?" do
     describe "given a target with an attribute that matches the Parameter's attribute" do
       let(:target) { SearchTarget.new(property: "search_value") }
-      let(:subject) { MatchAttributeValue.new(:property, "search_value") }
 
       it "returns true" do
-        expect(subject.match?(target)).to be_truthy
+        matcher = MatchAttributeValue.new
+        matcher.attribute = :property
+        matcher.desired_value = "search_value"
+        expect(matcher.match?(target)).to be_truthy
       end
     end
 
     describe "given a value with spaces" do
       let(:target) { SearchTarget.new(property: "search value") }
-      let(:subject) { MatchAttributeValue.new(:property, "search value") }
 
       it "returns true" do
-        expect(subject.match?(target)).to be_truthy
+        matcher = MatchAttributeValue.new
+        matcher.attribute = :property
+        matcher.desired_value = "search value"
+        expect(matcher.match?(target)).to be_truthy
       end
     end
 
     describe "given a target with an attribute that does not match the Parameter's attribute" do
       let(:target) { SearchTarget.new(property: "other_value") }
-      let(:subject) { MatchAttributeValue.new(:property, "search_value") }
 
       it "returns false" do
-        expect(subject.match?(target)).to be_falsey
+        matcher = MatchAttributeValue.new
+        matcher.attribute = :property
+        matcher.desired_value = "search_value"
+        expect(matcher.match?(target)).to be_falsey
       end
     end
 
     describe "if the target doesn't have the attribute" do
       let(:target) { SearchTarget.new(property: "search_value") }
-      let(:subject) { MatchAttribute.new(:bad_attr, "search_value") }
 
       it "is false" do
-        expect(subject.match?(target)).to be_falsey
+        matcher = MatchAttributeValue.new
+        matcher.attribute = :bat_attr
+        matcher.desired_value = "search_value"
+        expect(matcher.match?(target)).to be_falsey
       end
     end
   end

--- a/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe MatchAttributeValue do
         matcher = MatchAttributeValue.new
         matcher.attribute = :property
         matcher.desired_value = "search_value"
+        matcher.operator = "="
         expect(matcher.match?(target)).to be_truthy
       end
     end
@@ -21,6 +22,7 @@ RSpec.describe MatchAttributeValue do
         matcher = MatchAttributeValue.new
         matcher.attribute = :property
         matcher.desired_value = "search value"
+        matcher.operator = "="
         expect(matcher.match?(target)).to be_truthy
       end
     end
@@ -32,6 +34,7 @@ RSpec.describe MatchAttributeValue do
         matcher = MatchAttributeValue.new
         matcher.attribute = :property
         matcher.desired_value = "search_value"
+        matcher.operator = "="
         expect(matcher.match?(target)).to be_falsey
       end
     end
@@ -43,6 +46,7 @@ RSpec.describe MatchAttributeValue do
         matcher = MatchAttributeValue.new
         matcher.attribute = :bat_attr
         matcher.desired_value = "search_value"
+        matcher.operator = "="
         expect(matcher.match?(target)).to be_falsey
       end
     end

--- a/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_attribute_value_spec.rb
@@ -51,26 +51,26 @@ RSpec.describe MatchAttributeValue do
   describe "build_me?" do
     let(:search_option) { instance_double(QueryStringSearch::SearchOption) }
 
-    describe "given a non-nil search_type and search_param" do
+    describe "given a non-nil attribute and desired_value" do
       it "is true" do
-        allow(search_option).to receive(:search_type).and_return(rand.to_s)
-        allow(search_option).to receive(:search_param).and_return(rand.to_s)
+        allow(search_option).to receive(:attribute).and_return(rand.to_s)
+        allow(search_option).to receive(:desired_value).and_return(rand.to_s)
         expect(MatchAttributeValue.build_me?(search_option)).to be_truthy
       end
     end
 
-    describe "given a nil search_type or search_param" do
+    describe "given a nil attribute or desired_value" do
       it "is false" do
-        allow(search_option).to receive(:search_type).and_return(rand.to_s)
-        allow(search_option).to receive(:search_param).and_return(nil)
+        allow(search_option).to receive(:attribute).and_return(rand.to_s)
+        allow(search_option).to receive(:desired_value).and_return(nil)
         expect(MatchAttributeValue.build_me?(search_option)).to be_falsey
 
-        allow(search_option).to receive(:search_type).and_return(nil)
-        allow(search_option).to receive(:search_param).and_return(rand.to_s)
+        allow(search_option).to receive(:attribute).and_return(nil)
+        allow(search_option).to receive(:desired_value).and_return(rand.to_s)
         expect(MatchAttributeValue.build_me?(search_option)).to be_falsey
 
-        allow(search_option).to receive(:search_type).and_return(nil)
-        allow(search_option).to receive(:search_param).and_return(nil)
+        allow(search_option).to receive(:attribute).and_return(nil)
+        allow(search_option).to receive(:desired_value).and_return(nil)
         expect(MatchAttributeValue.build_me?(search_option)).to be_falsey
       end
     end

--- a/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
@@ -26,21 +26,29 @@ RSpec.describe MatchMultipleAttributeValues do
   end
 
   describe "build_me?" do
+    let(:search_option) { instance_double(QueryStringSearch::SearchOption) }
+
     describe "given a search type and search param that contains a pipe" do
       it "is true" do
-        expect(MatchMultipleAttributeValues.build_me?(rand, "x|y")).to be_truthy
+        allow(search_option).to receive(:search_type).and_return(rand.to_s)
+        allow(search_option).to receive(:search_param).and_return("x|y")
+        expect(MatchMultipleAttributeValues.build_me?(search_option)).to be_truthy
       end
     end
 
     describe "given a search type and search param that starts with a pipe" do
       it "is false" do
-        expect(MatchMultipleAttributeValues.build_me?(rand, "|x|y")).to be_falsey
+        allow(search_option).to receive(:search_type).and_return(rand.to_s)
+        allow(search_option).to receive(:search_param).and_return("|x|y")
+        expect(MatchMultipleAttributeValues.build_me?(search_option)).to be_falsey
       end
     end
 
     describe "given a search type without a pipe" do
       it "is false" do
-        expect(MatchMultipleAttributeValues.build_me?(rand, "xy")).to be_falsey
+        allow(search_option).to receive(:search_type).and_return(rand.to_s)
+        allow(search_option).to receive(:search_param).and_return("xy")
+        expect(MatchMultipleAttributeValues.build_me?(search_option)).to be_falsey
       end
     end
   end

--- a/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
@@ -34,26 +34,26 @@ RSpec.describe MatchMultipleAttributeValues do
   describe "build_me?" do
     let(:search_option) { instance_double(QueryStringSearch::SearchOption) }
 
-    describe "given a search type and search param that contains a pipe" do
+    describe "given a search type and value that contains a pipe" do
       it "is true" do
-        allow(search_option).to receive(:search_type).and_return(rand.to_s)
-        allow(search_option).to receive(:search_param).and_return("x|y")
+        allow(search_option).to receive(:attribute).and_return(rand.to_s)
+        allow(search_option).to receive(:desired_value).and_return("x|y")
         expect(MatchMultipleAttributeValues.build_me?(search_option)).to be_truthy
       end
     end
 
-    describe "given a search type and search param that starts with a pipe" do
+    describe "given a search type and value that starts with a pipe" do
       it "is false" do
-        allow(search_option).to receive(:search_type).and_return(rand.to_s)
-        allow(search_option).to receive(:search_param).and_return("|x|y")
+        allow(search_option).to receive(:attribute).and_return(rand.to_s)
+        allow(search_option).to receive(:desired_value).and_return("|x|y")
         expect(MatchMultipleAttributeValues.build_me?(search_option)).to be_falsey
       end
     end
 
     describe "given a search type without a pipe" do
       it "is false" do
-        allow(search_option).to receive(:search_type).and_return(rand.to_s)
-        allow(search_option).to receive(:search_param).and_return("xy")
+        allow(search_option).to receive(:attribute).and_return(rand.to_s)
+        allow(search_option).to receive(:desired_value).and_return("xy")
         expect(MatchMultipleAttributeValues.build_me?(search_option)).to be_falsey
       end
     end

--- a/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_multiple_attribute_values_spec.rb
@@ -5,20 +5,26 @@ RSpec.describe MatchMultipleAttributeValues do
   describe "match?" do
     it "matches if the target's attribute is one of the values" do
       target = SearchTarget.new(property: "1994")
-      matcher = MatchMultipleAttributeValues.new(:property, "1994|1995")
+      matcher = MatchMultipleAttributeValues.new
+      matcher.attribute = :property
+      matcher.desired_value = "1994|1995"
       expect(matcher.match?(target)).to be_truthy
     end
 
     it "does not match if the target's attribute is not one of the values" do
       target = SearchTarget.new(property: "199")
-      matcher = MatchMultipleAttributeValues.new(:property, "1994|1995")
+      matcher = MatchMultipleAttributeValues.new
+      matcher.attribute = :property
+      matcher.desired_value = "1994|1995"
       expect(matcher.match?(target)).to be_falsey
     end
 
     describe "if the target doesn't have the attribute" do
       it "is false" do
         target = SearchTarget.new(property: "1994")
-        subject = MatchAttribute.new(:bad_attr, "1994|1995")
+        matcher = MatchMultipleAttributeValues.new
+        matcher.attribute = :bad_attr
+        matcher.desired_value = "1994|1995"
 
         expect(subject.match?(target)).to be_falsey
       end

--- a/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
@@ -57,19 +57,19 @@ RSpec.describe MatchNoAttribute do
   describe "build_me?" do
     let(:search_option) { instance_double(QueryStringSearch::SearchOption) }
 
-    describe "given a search param of 'none' or 'false'" do
+    describe "given a value of 'none' or 'false'" do
       it "is true" do
-        %w(none false).each do |search_param|
-          allow(search_option).to receive(:search_param).and_return(search_param)
+        %w(none false).each do |desired_value|
+          allow(search_option).to receive(:desired_value).and_return(desired_value)
           expect(MatchNoAttribute.build_me?(search_option)).to be_truthy
         end
       end
     end
 
-    describe "given a search param that is not 'none' or 'false'" do
+    describe "given a value that is not 'none' or 'false'" do
       it "is false" do
-        %w(one falsey).each do |search_param|
-          allow(search_option).to receive(:search_param).and_return(search_param)
+        %w(one falsey).each do |desired_value|
+          allow(search_option).to receive(:desired_value).and_return(desired_value)
           expect(MatchNoAttribute.build_me?(search_option)).to be_falsey
         end
       end

--- a/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
@@ -50,10 +50,13 @@ RSpec.describe MatchNoAttribute do
   end
 
   describe "build_me?" do
+    let(:search_option) { instance_double(QueryStringSearch::SearchOption) }
+
     describe "given a search param of 'none' or 'false'" do
       it "is true" do
         %w(none false).each do |search_param|
-          expect(MatchNoAttribute.build_me?(rand, search_param)).to be_truthy
+          allow(search_option).to receive(:search_param).and_return(search_param)
+          expect(MatchNoAttribute.build_me?(search_option)).to be_truthy
         end
       end
     end
@@ -61,7 +64,8 @@ RSpec.describe MatchNoAttribute do
     describe "given a search param that is not 'none' or 'false'" do
       it "is false" do
         %w(one falsey).each do |search_param|
-          expect(MatchNoAttribute.build_me?(rand, search_param)).to be_falsey
+          allow(search_option).to receive(:search_param).and_return(search_param)
+          expect(MatchNoAttribute.build_me?(search_option)).to be_falsey
         end
       end
     end

--- a/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
+++ b/spec/lib/query_string_search/matchers/match_no_attribute_spec.rb
@@ -5,46 +5,51 @@ RSpec.describe MatchNoAttribute do
   describe "match?" do
     describe "if the target's attribute is not nil" do
       let(:target) { SearchTarget.new(property: "search_value") }
-      let(:subject) { MatchNoAttribute.new(:property) }
 
       it "is false" do
-        expect(subject.match?(target)).to be_falsey
+        matcher = MatchNoAttribute.new
+        matcher.attribute = :property
+        expect(matcher.match?(target)).to be_falsey
       end
     end
 
     describe "if the target's attribute is true" do
       let(:target) { SearchTarget.new(property: true) }
-      let(:subject) { MatchNoAttribute.new(:property) }
 
       it "is true" do
-        expect(subject.match?(target)).to be_falsey
+        matcher = MatchNoAttribute.new
+        matcher.attribute = :property
+        expect(matcher.match?(target)).to be_falsey
       end
     end
 
     describe "if the target's attribute is false" do
       let(:target) { SearchTarget.new(property: false) }
-      let(:subject) { MatchNoAttribute.new(:property) }
 
       it "is true" do
-        expect(subject.match?(target)).to be_truthy
+        matcher = MatchNoAttribute.new
+        matcher.attribute = :property
+        expect(matcher.match?(target)).to be_truthy
       end
     end
 
     describe "if the target's attribute is nil" do
       let(:target) { SearchTarget.new(property: nil) }
-      let(:subject) { MatchNoAttribute.new(:property) }
 
       it "is true" do
-        expect(subject.match?(target)).to be_truthy
+        matcher = MatchNoAttribute.new
+        matcher.attribute = :property
+        expect(matcher.match?(target)).to be_truthy
       end
     end
 
     describe "if the target doesn't have the attribute" do
       let(:target) { SearchTarget.new(property: rand) }
-      let(:subject) { MatchNoAttribute.new(:bad_attr) }
 
       it "is false" do
-        expect(subject.match?(target)).to be_falsey
+        matcher = MatchNoAttribute.new
+        matcher.attribute = :bad_attr
+        expect(matcher.match?(target)).to be_falsey
       end
     end
   end

--- a/spec/lib/query_string_search/search_option_spec.rb
+++ b/spec/lib/query_string_search/search_option_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe QueryStringSearch::SearchOption do
 
       it "correctly splits the attribute, value and operator" do
         equal_option = QueryStringSearch::SearchOption.new("test=2")
-        expect(equal_option.search_type).to eq(:test)
-        expect(equal_option.search_param).to eq("2")
+        expect(equal_option.attribute).to eq(:test)
+        expect(equal_option.desired_value).to eq("2")
         expect(equal_option.operator).to eq("=")
       end
     end
@@ -21,12 +21,12 @@ RSpec.describe QueryStringSearch::SearchOption do
         less_than = QueryStringSearch::SearchOption.new(less_than_query_string)
         greater_or_equal = QueryStringSearch::SearchOption.new(greater_than_or_equal_query)
 
-        expect(less_than.search_type).to eq(:test)
-        expect(less_than.search_param).to eq("1")
+        expect(less_than.attribute).to eq(:test)
+        expect(less_than.desired_value).to eq("1")
         expect(less_than.operator).to eq("<")
 
-        expect(greater_or_equal.search_type).to eq(:test)
-        expect(greater_or_equal.search_param).to eq("2")
+        expect(greater_or_equal.attribute).to eq(:test)
+        expect(greater_or_equal.desired_value).to eq("2")
         expect(greater_or_equal.operator).to eq(">=")
       end
     end

--- a/spec/lib/query_string_search/search_option_spec.rb
+++ b/spec/lib/query_string_search/search_option_spec.rb
@@ -1,0 +1,34 @@
+require_relative "../../../lib/query_string_search/search_option"
+
+RSpec.describe QueryStringSearch::SearchOption do
+  describe "new" do
+    describe "with equality operator" do
+      let(:equal_query) { "test=2" }
+
+      it "correctly splits the attribute, value and operator" do
+        equal_option = QueryStringSearch::SearchOption.new("test=2")
+        expect(equal_option.search_type).to eq(:test)
+        expect(equal_option.search_param).to eq("2")
+        expect(equal_option.operator).to eq("=")
+      end
+    end
+
+    describe "with inequality operators" do
+      let(:less_than_query_string) { "test<1" }
+      let(:greater_than_or_equal_query) { "test>=2" }
+
+      it "correctly splits the attribute, value and operator" do
+        less_than = QueryStringSearch::SearchOption.new(less_than_query_string)
+        greater_or_equal = QueryStringSearch::SearchOption.new(greater_than_or_equal_query)
+
+        expect(less_than.search_type).to eq(:test)
+        expect(less_than.search_param).to eq("1")
+        expect(less_than.operator).to eq("<")
+
+        expect(greater_or_equal.search_type).to eq(:test)
+        expect(greater_or_equal.search_param).to eq("2")
+        expect(greater_or_equal.operator).to eq(">=")
+      end
+    end
+  end
+end

--- a/spec/lib/query_string_search/search_options_spec.rb
+++ b/spec/lib/query_string_search/search_options_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe QueryStringSearch::SearchOptions do
   describe "parse" do
     describe "with a single-element and multi-element query_string" do
       let(:single_query_string) { "test=filter" }
-      let(:multi_query_string) { "test=filter,test2=test%20attribute" }
+      let(:multi_query_string) { "test=filter,test2=test attribute" }
       let(:single_element) { QueryStringSearch::SearchOptions.parse(single_query_string) }
       let(:multi_element) { QueryStringSearch::SearchOptions.parse(multi_query_string) }
 

--- a/spec/lib/query_string_search/search_options_spec.rb
+++ b/spec/lib/query_string_search/search_options_spec.rb
@@ -1,72 +1,33 @@
 require_relative "../../../lib/query_string_search/search_options"
 
 RSpec.describe QueryStringSearch::SearchOptions do
-  describe "new" do
-    describe "with inequality operators" do
-      let(:less_than_query_string) { "test<1" }
-      let(:greater_than_or_equal_query) { "test>=2" }
-
-      it "correctly splits the attribute, value and operator" do
-        less_than = QueryStringSearch::SearchOptions.new(less_than_query_string)
-        greater_or_equal = QueryStringSearch::SearchOptions.new(greater_than_or_equal_query)
-
-        expect(less_than.search_type).to eq(:test)
-        expect(less_than.search_param).to eq("1")
-        expect(less_than.operator).to eq("<")
-
-        expect(greater_or_equal.search_type).to eq(:test)
-        expect(greater_or_equal.search_param).to eq("2")
-        expect(greater_or_equal.operator).to eq(">=")
+  describe "parse" do
+    describe "with a single-element query_string" do
+      it "returns a collection of a single search option" do
+        option_double = Object.new
+        expect(QueryStringSearch::SearchOption).to receive(:new).with("test=filter").and_return(option_double)
+        expect(QueryStringSearch::SearchOptions.parse("test=filter")).to eq([option_double])
       end
     end
-  end
 
-  describe "parse" do
-    describe "with a single-element and multi-element query_string" do
-      let(:single_query_string) { "test=filter" }
+    describe "with a multi-element query_string" do
       let(:multi_query_string) { "test=filter,test2=test attribute" }
-      let(:single_element) { QueryStringSearch::SearchOptions.parse(single_query_string) }
-      let(:multi_element) { QueryStringSearch::SearchOptions.parse(multi_query_string) }
-
-      describe "returns a collection" do
-        it "that is enumerable" do
-          [single_element, multi_element].each do |it|
-            expect(it).to respond_to(:each)
-          end
-        end
-
-        describe "whose contents" do
-          it "have search_type that are symbols" do
-            expect(single_element.collect(&:search_type)).to eq([:test])
-            expect(multi_element.collect(&:search_type)).to eq([:test, :test2])
-          end
-
-          it "have search_param that are unescaped strings" do
-            expect(single_element.collect(&:search_param)).to eq(["filter"])
-            expect(multi_element.collect(&:search_param)).to eq(["filter", "test attribute"])
-          end
-        end
+      it "returns a collection of a multiple search options" do
+        option_double1 = Object.new
+        option_double2 = Object.new
+        expect(QueryStringSearch::SearchOption).to receive(:new).with("test=filter").and_return(option_double1)
+        expect(QueryStringSearch::SearchOption).to receive(:new).with("test2=test attribute").and_return(option_double2)
+        expect(QueryStringSearch::SearchOptions.parse(multi_query_string)).to eq([option_double1, option_double2])
       end
     end
 
     describe "with a nil" do
       let(:nil_element) { QueryStringSearch::SearchOptions.parse(nil) }
-      describe "returns a collection" do
-        it "that is enumerable" do
-          expect(nil_element).to respond_to(:each)
-        end
+      it "creates a collection with one nil search option" do
+        option_double = Object.new
+        expect(QueryStringSearch::SearchOption).to receive(:new).with(nil).and_return(option_double)
 
-        it "with one element" do
-          expect(nil_element.count).to eq(1)
-        end
-
-        it "with nil search_type" do
-          expect(nil_element.first.search_type).to be_nil
-        end
-
-        it "with nil search_param" do
-          expect(nil_element.first.search_param).to be_nil
-        end
+        expect(QueryStringSearch::SearchOptions.parse(nil)).to eq([option_double])
       end
     end
   end

--- a/spec/lib/query_string_search/search_options_spec.rb
+++ b/spec/lib/query_string_search/search_options_spec.rb
@@ -1,6 +1,26 @@
 require_relative "../../../lib/query_string_search/search_options"
 
 RSpec.describe QueryStringSearch::SearchOptions do
+  describe "new" do
+    describe "with inequality operators" do
+      let(:less_than_query_string) { "test<1" }
+      let(:greater_than_or_equal_query) { "test>=2" }
+
+      it "correctly splits the attribute, value and operator" do
+        less_than = QueryStringSearch::SearchOptions.new(less_than_query_string)
+        greater_or_equal = QueryStringSearch::SearchOptions.new(greater_than_or_equal_query)
+
+        expect(less_than.search_type).to eq(:test)
+        expect(less_than.search_param).to eq("1")
+        expect(less_than.operator).to eq("<")
+
+        expect(greater_or_equal.search_type).to eq(:test)
+        expect(greater_or_equal.search_param).to eq("2")
+        expect(greater_or_equal.operator).to eq(">=")
+      end
+    end
+  end
+
   describe "parse" do
     describe "with a single-element and multi-element query_string" do
       let(:single_query_string) { "test=filter" }


### PR DESCRIPTION
TL/DR version, this implements #8 

Long version is that there's a lot of gross refactoring in the middle. Mostly around the naming of things and where certain responsibilities were. I'l try to show off the highlights.

The main problem we had to resolve was that the existing code really expected to compare two strings. Obviously with inequality operators we need to compare numbers. 

And we had to figure out how to indicate these operators in the query string. I went with a query string like "movies?q=star_rating>5". But the query string parsing expected the key and value to be separated by a "=". Meaning I had to improve the parsing **and** save that operator for later use.

We start off with documenting the new feature: ea27839
Then on to adding a feature test: f251f7f
Parsing refactoring introduced in: 44c6a30
Then there's _a lot_ of refactoring commits
In 7245745 I get back to doing real work and change Comparator so that it can accept operators.
With that I can implement the gross version of inequality comparison in 1f28de4
And in the remaining commits I refactor that gross version to a less gross version. At least we're no longer doing eval!

Because many things got refactored multiple times I recommend not commenting on individual commits. Comment on the final version of the code.
